### PR TITLE
改用数组，加快运行速度

### DIFF
--- a/Tests/TestMain.cs
+++ b/Tests/TestMain.cs
@@ -47,12 +47,12 @@ namespace Tests
                              where line.Length > 0
                              select new UMatrixRule(line)).ToList().AsReadOnly();
 
-            var rules = new LinkedList<UMatrixRule>(baseRules);
+            var rules = new List<UMatrixRule>(baseRules);
             var r1 = new UMatrixRule("appledaily.com rtnvideo1.appledaily.com.tw media allow");
             var r2 = new UMatrixRule("appledaily.com video.appledaily.com.tw media allow");
 
-            rules.AddLast(r1);
-            rules.AddLast(r2);
+            rules.Add(r1);
+            rules.Add(r2);
 
             Program.Merge(rules, 2);
 
@@ -62,14 +62,14 @@ namespace Tests
             Assert.Contains(r3, rules);
 
 
-            rules = new LinkedList<UMatrixRule>(baseRules);
+            rules = new List<UMatrixRule>(baseRules);
             r1 = new UMatrixRule("qq.com captcha.qq.com script allow");
             r2 = new UMatrixRule("qq.com check.ptlogin2.qq.com script allow");
             r3 = new UMatrixRule("mp.weixin.qq.com qq.com script block");
 
-            rules.AddLast(r1);
-            rules.AddLast(r2);
-            rules.AddLast(r3);
+            rules.Add(r1);
+            rules.Add(r2);
+            rules.Add(r3);
             Program.Merge(rules, 2);
             Assert.Contains(r1, rules);
             Assert.Contains(r2, rules);
@@ -77,14 +77,14 @@ namespace Tests
 
 
 
-            rules = new LinkedList<UMatrixRule>(baseRules);
+            rules = new List<UMatrixRule>(baseRules);
             r1 = new UMatrixRule("thestandnews.com s-static.ak.facebook.com frame allow");
             r2 = new UMatrixRule("appledaily.com.tw s-static.ak.facebook.com frame allow");
             r3 = new UMatrixRule("appledaily.com.tw www.facebook.com frame allow");
 
-            rules.AddLast(r1);
-            rules.AddLast(r2);
-            rules.AddLast(r3);
+            rules.Add(r1);
+            rules.Add(r2);
+            rules.Add(r3);
             Program.Merge(rules, 3);
             Assert.Contains(new UMatrixRule("* facebook.com frame allow"), rules);
             Assert.DoesNotContain(r1, rules);
@@ -100,7 +100,7 @@ namespace Tests
 * www.google.com css allow
 * www.facebook.com css allow";
 
-            var rules = new LinkedList<UMatrixRule>(from line in input.Split("\r\n")
+            var rules = new List<UMatrixRule>(from line in input.Split("\r\n")
                                                     where line.Length > 0
                                                     select new UMatrixRule(line));
             Program.Merge(rules, 2);
@@ -122,15 +122,15 @@ namespace Tests
 * 1st-party script allow
 * www.baidu.com cookie block
 * tieba.baidu.com cookie block";
-            var rules = new LinkedList<UMatrixRule>(from line in input.Split("\r\n")
-                where line.Length > 0
-                select new UMatrixRule(line));
+            var rules = new List<UMatrixRule>(from line in input.Split("\r\n")
+                                                    where line.Length > 0
+                                                    select new UMatrixRule(line));
             Program.Merge(rules, 2);
             Assert.Contains(new UMatrixRule("* baidu.com cookie block"), rules);
 
         }
 
-        [Fact(DisplayName ="Merge wildcard type with action block")]
+        [Fact(DisplayName = "Merge wildcard type with action block")]
         public static void TestMergeTypeWildcardBlock()
         {
             var input = @"
@@ -144,9 +144,9 @@ namespace Tests
 * 1st-party script allow
 * baidu.com css block
 * baidu.com image block";
-            var rules = new LinkedList<UMatrixRule>(from line in input.Split("\r\n")
-                where line.Length > 0
-                select new UMatrixRule(line));
+            var rules = new List<UMatrixRule>(from line in input.Split("\r\n")
+                                                    where line.Length > 0
+                                                    select new UMatrixRule(line));
             Program.Merge(rules, 2);
             Assert.Contains(new UMatrixRule("* baidu.com * block"), rules);
 

--- a/uMatrixCleaner/Program.cs
+++ b/uMatrixCleaner/Program.cs
@@ -159,10 +159,8 @@ namespace uMatrixCleaner
                             Console.Write("合并");
                             for (int j = rules.Count - 1; j >= i && toRemove.Count > 0; j--)
                             {
-                                if (toRemove.Contains(rules[j]))
+                                if (toRemove.Remove(rules[j]))
                                 {
-                                    toRemove.Remove(rules[j]);
-
                                     Console.WriteLine("\t\t" + rules[j]);
                                     rrManager.NotifyItemDeleted(rules[j]);
                                     rules[j] = rules[rules.Count - 1];

--- a/uMatrixCleaner/Program.cs
+++ b/uMatrixCleaner/Program.cs
@@ -157,10 +157,12 @@ namespace uMatrixCleaner
                             newRules.Add(generalizedRule); //新规则不再参与合并，否则会有叠加效应
 
                             Console.Write("合并");
-                            for (int j = rules.Count - 1; j >= i; j--)
+                            for (int j = rules.Count - 1; j >= i && toRemove.Count > 0; j--)
                             {
                                 if (toRemove.Contains(rules[j]))
                                 {
+                                    toRemove.Remove(rules[j]);
+
                                     Console.WriteLine("\t\t" + rules[j]);
                                     rrManager.NotifyItemDeleted(rules[j]);
                                     rules[j] = rules[rules.Count - 1];

--- a/uMatrixCleaner/Program.cs
+++ b/uMatrixCleaner/Program.cs
@@ -29,13 +29,13 @@ namespace uMatrixCleaner
                 //r=>r.Source.Value=="*" && r.Destination.Value!="*" && (r.Type.HasFlag(TypePredicate.Script) || r.Type.HasFlag(TypePredicate.Frame)),
                 r=>r.Selector.Destination.Value=="simg.sinajs.cn"
             };
-            var workingRules = new LinkedList<UMatrixRule>(rules);
+            //var workingRules = new LinkedList<UMatrixRule>(rules);
             //Deduplicate(workingRules, examptedFromRemoving);
 
 
             var sw = new System.Diagnostics.Stopwatch();
             sw.Start();
-            Merge(workingRules, 2);
+            Merge(rules.ToList(), 2);
             sw.Stop();
             Console.WriteLine($"合并用时{sw.ElapsedMilliseconds}毫秒");
 
@@ -97,7 +97,13 @@ namespace uMatrixCleaner
 
         private static int savedSearch = 0;
 
-        public static void Merge(LinkedList<UMatrixRule> rules, int thresholdToRemove)
+        /// <summary>
+        /// 返回新增的规则
+        /// </summary>
+        /// <param name="rules"></param>
+        /// <param name="thresholdToRemove"></param>
+        /// <returns></returns>
+        public static void Merge(List<UMatrixRule> rules, int thresholdToRemove)
         {
             HashSet<UMatrixRule> notWorkingRules = new HashSet<UMatrixRule>();
             savedSearch = 0;
@@ -106,12 +112,9 @@ namespace uMatrixCleaner
 
             List<UMatrixRule> newRules = new List<UMatrixRule>();
 
-            LinkedListNode<UMatrixRule> nextNode = rules.First;
-            while (nextNode != null)
+            for (int i = 0; i < rules.Count; i++)
             {
-                var currentNode = nextNode;
-                var currentRule = currentNode.Value;
-                nextNode = currentNode.Next;
+                var currentRule = rules[i];
 
 
                 var g = currentRule.Selector.Generalize();
@@ -124,19 +127,17 @@ namespace uMatrixCleaner
                         break;
                     }
 
-                    LinkedListNode<UMatrixRule>[] subRules = null;
-
-                    subRules = (from r in rules.EnumerateNodes()
-                                where g.IsProperSuperOf(r.Value.Selector) && r.Value.IsAllow == currentRule.IsAllow
-                                select r).ToArray();
+                    var subRules = (from r in rules
+                                    where g.IsProperSuperOf(r.Selector) && r.IsAllow == currentRule.IsAllow
+                                    select r).ToArray();
 
 
                     if (subRules.Length >= thresholdToRemove)
                     {
-                        var toRemove = new ConcurrentBag<LinkedListNode<UMatrixRule>>();
-                        foreach(var subRule in subRules)
+                        var toRemove = new HashSet<UMatrixRule>();
+                        foreach (var subRule in subRules)
                         {
-                            var superOrJointRules = rrManager.GetSuperOrJointRules(subRule.Value).Where(r => r.IsAllow != subRule.Value.IsAllow);
+                            var superOrJointRules = rrManager.GetSuperOrJointRules(subRule).Where(r => r.IsAllow != subRule.IsAllow);
                             if (superOrJointRules.Any(s => s.Priority > generalizedRule.Priority))
                             {
                                 //不能删除
@@ -150,21 +151,21 @@ namespace uMatrixCleaner
 
                         if (toRemove.Count >= thresholdToRemove)
                         {
-                            Debug.Assert(toRemove.Contains(currentNode) || toRemove.Contains(currentNode) == false,
+                            Debug.Assert(toRemove.Contains(currentRule) || toRemove.Contains(currentRule) == false,
                                 "当前规则可能被更高优先级规则锁定，但当前规则的推广规则可能可用于合并其他规则。");
 
                             newRules.Add(generalizedRule); //新规则不再参与合并，否则会有叠加效应
 
-                            while (nextNode != null && toRemove.Contains(nextNode))
-                                nextNode = nextNode.Next;
-
                             Console.Write("合并");
-                            foreach (var node in toRemove)
+                            for (int j = rules.Count - 1; j >= i; j--)
                             {
-                                Console.WriteLine("\t\t" + node.Value);
-                                rules.Remove(node);
-
-                                rrManager.NotifyItemDeleted(node.Value);
+                                if (toRemove.Contains(rules[j]))
+                                {
+                                    Console.WriteLine("\t\t" + rules[j]);
+                                    rrManager.NotifyItemDeleted(rules[j]);
+                                    rules[j] = rules[rules.Count - 1];
+                                    rules.RemoveAt(rules.Count - 1);
+                                }
                             }
 
                             Console.WriteLine("\t为" + generalizedRule);
@@ -179,9 +180,7 @@ namespace uMatrixCleaner
                     g = g.Generalize();
                 }
             }
-
-            foreach (var newRule in newRules)
-                rules.AddLast(newRule);
+            rules.AddRange(newRules);
         }
     }
 }

--- a/uMatrixCleaner/Program.cs
+++ b/uMatrixCleaner/Program.cs
@@ -108,7 +108,7 @@ namespace uMatrixCleaner
             HashSet<UMatrixRule> notWorkingRules = new HashSet<UMatrixRule>();
             savedSearch = 0;
 
-            var rrManager = new RuleRelationshipManager(rules.ToArray());
+            var rrManager = new RuleRelationshipManager(rules);
 
             List<UMatrixRule> newRules = new List<UMatrixRule>();
 

--- a/uMatrixCleaner/RuleRelationshipManager.cs
+++ b/uMatrixCleaner/RuleRelationshipManager.cs
@@ -15,7 +15,7 @@ namespace uMatrixCleaner
         private readonly Task initTask;
 
 
-        public RuleRelationshipManager(UMatrixRule[] rules)
+        public RuleRelationshipManager(IList<UMatrixRule> rules)
         {
             superOrJointRulesDictionary = new ConcurrentDictionary<UMatrixRule, HashSet<UMatrixRule>>();
             initTask = new Task(rs =>

--- a/uMatrixCleaner/Selector.cs
+++ b/uMatrixCleaner/Selector.cs
@@ -310,13 +310,14 @@ namespace uMatrixCleaner
         /// <returns></returns>
         public bool IsSubDomain(HostPredicate other)
         {
-#if DEBUG
-            var st = new StackTrace(false);
-            var f = st.GetFrame(1);
-            if (f.GetMethod().Name != nameof(IsSubDomain))
-                Debug.Assert(IsDomain == false || this.IsSubDomain(this));
-#endif
+            Debug.Assert(IsDomain == false || this.IsSubDomainCore(this));
 
+            return IsSubDomainCore(other);
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        private bool IsSubDomainCore(HostPredicate other)
+        {
             if (other.HostType == UriHostNameType.Basic)
                 return false;
 
@@ -326,7 +327,6 @@ namespace uMatrixCleaner
 
             if (IsDomain)
             {
-
                 //可能一个主机谓词是com，另一个是google.com，则后者被会判断为前者的子域名。
                 //如果要严谨一点，需要调用DomainParser，这个调用很慢。
 
@@ -345,7 +345,6 @@ namespace uMatrixCleaner
 
             throw new NotSupportedException($"不能对{Value}调用{nameof(IsSubDomain)}()。");
         }
-
 
 
         /// <summary>


### PR DESCRIPTION
在`Merge`方法里，不需要保留规则的顺序，于是当删除数组中的一个元素时，可以用数组末尾的元素来填充当前位置。这个操作的复杂度是O(1)，与链表删除相同。

另外，`RuleRelationshipManager`需要可直接访问的集合结构，以便并行。本来调用方用链表存储，需要再转换为数组。现在如果调用方直接用数组保存了，调用`RuleRelationshipManager`时就不用再转换了，可以节省一点时间。

其次，数组的`for`循环比链表的`while`循环更加直观。
